### PR TITLE
feat: add Cdc suffix to raw Cadence functions

### DIFF
--- a/lib/node/fusd.ts
+++ b/lib/node/fusd.ts
@@ -20,7 +20,7 @@ export const deployFusd = async (account: IFlowAccount) => {
  * @throws If execution will be halted
  * @returns {Promise<*>}
  * */
-export const setupFusdOnAccount = (account: IFlowAccount) => {
+export const setupFusdOnAccountCdc = (account: IFlowAccount) => {
   const name = 'fusd/setup_account'
   const signers = [account]
   return transact({
@@ -37,7 +37,7 @@ export const setupFusdOnAccount = (account: IFlowAccount) => {
  * @throws If execution will be halted
  * @returns {Promise<*>}
  * */
-export const mintFusdToAccount = async (
+export const mintFusdToAccountCdc = async (
   admin: IFlowAccount,
   recipient: IFlowAccount,
   amount: number,
@@ -59,7 +59,7 @@ export const mintFusdToAccount = async (
  * @throws If execution will be halted
  * @returns {Promise<*>}
  * */
-export const getFusdBalance = async (account: IFlowAccount) => {
+export const getFusdBalanceCdc = async (account: IFlowAccount) => {
   const name = 'fusd/get_balance'
   const args = [arg(account.address, t.Address)]
 
@@ -74,7 +74,7 @@ export const getFusdBalance = async (account: IFlowAccount) => {
  * @throws If execution will be halted
  * @returns {Promise<*>}
  * */
-export const transferFusd = async (
+export const transferFusdCdc = async (
   amount: number,
   recipient: string,
   signer: IFlowAccount,

--- a/lib/shared/fusd.spec.ts
+++ b/lib/shared/fusd.spec.ts
@@ -1,0 +1,43 @@
+import { IFlowAccount } from '../type/i-flow-account'
+import { getFusdBalanceCdc } from '../node/fusd'
+import { getFusdBalance } from './fusd'
+
+jest.mock('../node/fusd')
+
+// Necessary to get TypeScript typings
+const mockedGetFusdBalanceCdc = getFusdBalanceCdc as jest.MockedFunction<
+  typeof getFusdBalanceCdc
+>
+
+// Values used in tests
+const adminAccountMock: IFlowAccount = {
+  address: '12345',
+  privateKey: '12345',
+}
+
+describe('getFusdBalance()', () => {
+  it('returns FUSD balance 0', async () => {
+    mockedGetFusdBalanceCdc.mockResolvedValueOnce('0.00000000')
+    const balance = await getFusdBalance(adminAccountMock)
+    expect(balance).toBe(0)
+  })
+
+  it('returns FUSD balance above 0', async () => {
+    mockedGetFusdBalanceCdc.mockResolvedValueOnce('100.00000000')
+    const balance = await getFusdBalance(adminAccountMock)
+    expect(balance).toBe(100)
+  })
+
+  it('returns FUSD balance below 0', async () => {
+    mockedGetFusdBalanceCdc.mockResolvedValueOnce('-100.00000000')
+    const balance = await getFusdBalance(adminAccountMock)
+    expect(balance).toBe(-100)
+  })
+
+  it('throws an error if returned balance value is not a number', async () => {
+    mockedGetFusdBalanceCdc.mockResolvedValueOnce('abc')
+    await expect(getFusdBalance(adminAccountMock)).rejects.toThrow(
+      'FUSD balance is not a number: abc',
+    )
+  })
+})

--- a/lib/shared/fusd.ts
+++ b/lib/shared/fusd.ts
@@ -1,0 +1,18 @@
+import { IFlowAccount } from '../type/i-flow-account'
+import { getFusdBalanceCdc } from '../node/fusd'
+
+/**
+ * Returns FUSD balance for an account
+ *
+ * @param account - account to check the balance
+ * @returns FUSD balance on the account
+ */
+export const getFusdBalance = async (account: IFlowAccount): Promise<number> => {
+  const fusdAmount = await getFusdBalanceCdc(account)
+  const balance = parseFloat(fusdAmount)
+
+  if (isNaN(balance)) {
+    throw new Error(`FUSD balance is not a number: ${fusdAmount}`)
+  }
+  return balance
+}


### PR DESCRIPTION
Closes #22 

This pull request contains:  

- [x] Add suffix `Cdc` to the end of all raw Cadence functions
- [x] Add `getFusdBalance` wrapper function which calls the raw `getFusdBalanceCdc` function